### PR TITLE
fix: hotgo.sql CHARSET utf8mb4 sure compat for v2.13.1

### DIFF
--- a/server/storage/data/hotgo.sql
+++ b/server/storage/data/hotgo.sql
@@ -64,7 +64,7 @@ CREATE TABLE IF NOT EXISTS `hg_addon_hgexample_table` (
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '修改时间',
   `deleted_at` datetime DEFAULT NULL COMMENT '删除时间'
-) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb3 COMMENT='插件_案例_表格';
+) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COMMENT='插件_案例_表格';
 
 --
 -- 转存表中的数据 `hg_addon_hgexample_table`
@@ -94,7 +94,7 @@ CREATE TABLE IF NOT EXISTS `hg_admin_cash` (
   `msg` varchar(128) NOT NULL COMMENT '处理结果',
   `handle_at` datetime DEFAULT NULL COMMENT '处理时间',
   `created_at` datetime NOT NULL COMMENT '申请时间'
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb3 COMMENT='管理员_提现记录表';
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COMMENT='管理员_提现记录表';
 
 --
 -- 转存表中的数据 `hg_admin_cash`
@@ -125,7 +125,7 @@ CREATE TABLE IF NOT EXISTS `hg_admin_credits_log` (
   `status` tinyint(1) DEFAULT '1' COMMENT '状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '修改时间'
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb3 COMMENT='管理员_资产变动表';
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COMMENT='管理员_资产变动表';
 
 --
 -- 转存表中的数据 `hg_admin_credits_log`
@@ -157,7 +157,7 @@ CREATE TABLE IF NOT EXISTS `hg_admin_dept` (
   `status` tinyint(1) DEFAULT '1' COMMENT '部门状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间'
-) ENGINE=InnoDB AUTO_INCREMENT=110 DEFAULT CHARSET=utf8mb3 COMMENT='管理员_部门';
+) ENGINE=InnoDB AUTO_INCREMENT=110 DEFAULT CHARSET=utf8mb4 COMMENT='管理员_部门';
 
 --
 -- 转存表中的数据 `hg_admin_dept`
@@ -209,7 +209,7 @@ CREATE TABLE IF NOT EXISTS `hg_admin_member` (
   `status` tinyint(1) DEFAULT '1' COMMENT '状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '修改时间'
-) ENGINE=InnoDB AUTO_INCREMENT=13 DEFAULT CHARSET=utf8mb3 COMMENT='管理员_用户表';
+) ENGINE=InnoDB AUTO_INCREMENT=13 DEFAULT CHARSET=utf8mb4 COMMENT='管理员_用户表';
 
 --
 -- 转存表中的数据 `hg_admin_member`
@@ -232,7 +232,7 @@ INSERT INTO `hg_admin_member` (`id`, `dept_id`, `role_id`, `real_name`, `usernam
 CREATE TABLE IF NOT EXISTS `hg_admin_member_post` (
   `member_id` bigint NOT NULL COMMENT '管理员ID',
   `post_id` bigint NOT NULL COMMENT '岗位ID'
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='管理员_用户岗位关联';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='管理员_用户岗位关联';
 
 --
 -- 转存表中的数据 `hg_admin_member_post`
@@ -255,7 +255,7 @@ INSERT INTO `hg_admin_member_post` (`member_id`, `post_id`) VALUES
 CREATE TABLE IF NOT EXISTS `hg_admin_member_role` (
   `member_id` bigint NOT NULL COMMENT '管理员ID',
   `role_id` bigint NOT NULL COMMENT '角色ID'
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='管理员_用户角色关联';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='管理员_用户角色关联';
 
 --
 -- 转存表中的数据 `hg_admin_member_role`
@@ -298,7 +298,7 @@ CREATE TABLE IF NOT EXISTS `hg_admin_menu` (
   `status` tinyint(1) DEFAULT '1' COMMENT '菜单状态',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间'
-) ENGINE=InnoDB AUTO_INCREMENT=2341 DEFAULT CHARSET=utf8mb3 COMMENT='管理员_菜单权限';
+) ENGINE=InnoDB AUTO_INCREMENT=2341 DEFAULT CHARSET=utf8mb4 COMMENT='管理员_菜单权限';
 
 --
 -- 转存表中的数据 `hg_admin_menu`
@@ -479,7 +479,7 @@ CREATE TABLE IF NOT EXISTS `hg_admin_notice` (
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间',
   `deleted_at` datetime DEFAULT NULL COMMENT '删除时间'
-) ENGINE=InnoDB AUTO_INCREMENT=35 DEFAULT CHARSET=utf8mb3 COMMENT='管理员_通知公告';
+) ENGINE=InnoDB AUTO_INCREMENT=35 DEFAULT CHARSET=utf8mb4 COMMENT='管理员_通知公告';
 
 --
 -- 转存表中的数据 `hg_admin_notice`
@@ -506,7 +506,7 @@ CREATE TABLE IF NOT EXISTS `hg_admin_notice_read` (
   `clicks` int DEFAULT '1' COMMENT '已读次数',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间',
   `created_at` datetime DEFAULT NULL COMMENT '阅读时间'
-) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8mb3 COMMENT='管理员_公告已读记录';
+) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8mb4 COMMENT='管理员_公告已读记录';
 
 --
 -- 转存表中的数据 `hg_admin_notice_read`
@@ -544,7 +544,7 @@ CREATE TABLE IF NOT EXISTS `hg_admin_oauth` (
   `status` tinyint(1) DEFAULT '1' COMMENT '状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime(1) DEFAULT NULL COMMENT '修改时间'
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='管理员_第三方登录';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='管理员_第三方登录';
 
 -- --------------------------------------------------------
 
@@ -565,7 +565,7 @@ CREATE TABLE IF NOT EXISTS `hg_admin_order` (
   `status` tinyint DEFAULT '1' COMMENT '状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '修改时间'
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb3 COMMENT='管理员_充值订单';
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COMMENT='管理员_充值订单';
 
 -- --------------------------------------------------------
 
@@ -582,7 +582,7 @@ CREATE TABLE IF NOT EXISTS `hg_admin_post` (
   `status` tinyint(1) NOT NULL COMMENT '状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间'
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb3 COMMENT='管理员_岗位';
+) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb4 COMMENT='管理员_岗位';
 
 --
 -- 转存表中的数据 `hg_admin_post`
@@ -615,7 +615,7 @@ CREATE TABLE IF NOT EXISTS `hg_admin_role` (
   `status` tinyint(1) NOT NULL DEFAULT '1' COMMENT '角色状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间'
-) ENGINE=InnoDB AUTO_INCREMENT=209 DEFAULT CHARSET=utf8mb3 COMMENT='管理员_角色信息';
+) ENGINE=InnoDB AUTO_INCREMENT=209 DEFAULT CHARSET=utf8mb4 COMMENT='管理员_角色信息';
 
 --
 -- 转存表中的数据 `hg_admin_role`
@@ -639,14 +639,14 @@ INSERT INTO `hg_admin_role` (`id`, `name`, `key`, `data_scope`, `custom_dept`, `
 
 CREATE TABLE IF NOT EXISTS `hg_admin_role_casbin` (
   `id` bigint NOT NULL,
-  `p_type` varchar(64) CHARACTER SET utf8mb3 COLLATE utf8_general_ci DEFAULT NULL,
-  `v0` varchar(256) CHARACTER SET utf8mb3 COLLATE utf8_general_ci DEFAULT NULL,
-  `v1` varchar(256) CHARACTER SET utf8mb3 COLLATE utf8_general_ci DEFAULT NULL,
-  `v2` varchar(256) CHARACTER SET utf8mb3 COLLATE utf8_general_ci DEFAULT NULL,
-  `v3` varchar(256) CHARACTER SET utf8mb3 COLLATE utf8_general_ci DEFAULT NULL,
-  `v4` varchar(256) CHARACTER SET utf8mb3 COLLATE utf8_general_ci DEFAULT NULL,
-  `v5` varchar(256) CHARACTER SET utf8mb3 COLLATE utf8_general_ci DEFAULT NULL
-) ENGINE=InnoDB AUTO_INCREMENT=309 DEFAULT CHARSET=utf8mb3 ROW_FORMAT=DYNAMIC COMMENT='管理员_casbin权限表';
+  `p_type` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `v0` varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `v1` varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `v2` varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `v3` varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `v4` varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `v5` varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL
+) ENGINE=InnoDB AUTO_INCREMENT=309 DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC COMMENT='管理员_casbin权限表';
 
 --
 -- 转存表中的数据 `hg_admin_role_casbin`
@@ -971,7 +971,7 @@ INSERT INTO `hg_admin_role_casbin` (`id`, `p_type`, `v0`, `v1`, `v2`, `v3`, `v4`
 CREATE TABLE IF NOT EXISTS `hg_admin_role_menu` (
   `role_id` bigint NOT NULL COMMENT '角色ID',
   `menu_id` bigint NOT NULL COMMENT '菜单ID'
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='管理员_角色菜单关联';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='管理员_角色菜单关联';
 
 --
 -- 转存表中的数据 `hg_admin_role_menu`
@@ -1381,7 +1381,7 @@ CREATE TABLE IF NOT EXISTS `hg_pay_log` (
   `status` tinyint DEFAULT '1' COMMENT '状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '修改时间'
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb3 COMMENT='支付_支付日志';
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COMMENT='支付_支付日志';
 
 -- --------------------------------------------------------
 
@@ -1403,7 +1403,7 @@ CREATE TABLE IF NOT EXISTS `hg_pay_refund` (
   `status` tinyint DEFAULT '1' COMMENT '退款状态',
   `created_at` datetime DEFAULT NULL COMMENT '申请时间',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间'
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='支付_退款记录';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='支付_退款记录';
 
 -- --------------------------------------------------------
 
@@ -1426,7 +1426,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_addons_config` (
   `status` tinyint(1) DEFAULT '1' COMMENT '状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间'
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb3 COMMENT='系统_插件配置';
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COMMENT='系统_插件配置';
 
 --
 -- 转存表中的数据 `hg_sys_addons_config`
@@ -1448,7 +1448,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_addons_install` (
   `status` tinyint(1) DEFAULT '1' COMMENT '状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间'
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb3 COMMENT='系统_插件安装记录';
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COMMENT='系统_插件安装记录';
 
 --
 -- 转存表中的数据 `hg_sys_addons_install`
@@ -1481,7 +1481,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_attachment` (
   `status` tinyint(1) NOT NULL DEFAULT '1' COMMENT '状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '修改时间'
-) ENGINE=InnoDB AUTO_INCREMENT=49 DEFAULT CHARSET=utf8mb3 COMMENT='系统_附件管理';
+) ENGINE=InnoDB AUTO_INCREMENT=49 DEFAULT CHARSET=utf8mb4 COMMENT='系统_附件管理';
 
 -- --------------------------------------------------------
 
@@ -1496,7 +1496,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_blacklist` (
   `status` tinyint(1) DEFAULT '1' COMMENT '状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间'
-) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8mb3 COMMENT='系统_访问黑名单';
+) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8mb4 COMMENT='系统_访问黑名单';
 
 --
 -- 转存表中的数据 `hg_sys_blacklist`
@@ -1530,7 +1530,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_config` (
   `status` tinyint(1) DEFAULT '1' COMMENT '状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间'
-) ENGINE=InnoDB AUTO_INCREMENT=129 DEFAULT CHARSET=utf8mb3 COMMENT='系统_配置';
+) ENGINE=InnoDB AUTO_INCREMENT=129 DEFAULT CHARSET=utf8mb4 COMMENT='系统_配置';
 
 --
 -- 转存表中的数据 `hg_sys_config`
@@ -1667,7 +1667,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_cron` (
   `status` tinyint(1) DEFAULT '1' COMMENT '任务状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间'
-) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb3 COMMENT='系统_定时任务';
+) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb4 COMMENT='系统_定时任务';
 
 --
 -- 转存表中的数据 `hg_sys_cron`
@@ -1696,7 +1696,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_cron_group` (
   `status` tinyint(1) DEFAULT '1' COMMENT '分组状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间'
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb3 COMMENT='系统_定时任务分组';
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COMMENT='系统_定时任务分组';
 
 --
 -- 转存表中的数据 `hg_sys_cron_group`
@@ -1725,7 +1725,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_dict_data` (
   `status` tinyint(1) DEFAULT '1' COMMENT '状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间'
-) ENGINE=InnoDB AUTO_INCREMENT=158 DEFAULT CHARSET=utf8mb3 COMMENT='系统_字典数据';
+) ENGINE=InnoDB AUTO_INCREMENT=158 DEFAULT CHARSET=utf8mb4 COMMENT='系统_字典数据';
 
 --
 -- 转存表中的数据 `hg_sys_dict_data`
@@ -1829,7 +1829,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_dict_type` (
   `status` tinyint(1) DEFAULT '1' COMMENT '字典类型状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间'
-) ENGINE=InnoDB AUTO_INCREMENT=39 DEFAULT CHARSET=utf8mb3 COMMENT='系统_字典类型';
+) ENGINE=InnoDB AUTO_INCREMENT=39 DEFAULT CHARSET=utf8mb4 COMMENT='系统_字典类型';
 
 --
 -- 转存表中的数据 `hg_sys_dict_type`
@@ -1878,7 +1878,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_ems_log` (
   `status` tinyint(1) DEFAULT '1' COMMENT '状态(1未验证,2已验证)',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间'
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb3 COMMENT='系统_邮件发送记录';
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COMMENT='系统_邮件发送记录';
 
 --
 -- 转存表中的数据 `hg_sys_ems_log`
@@ -1908,7 +1908,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_gen_codes` (
   `status` tinyint(1) DEFAULT '1' COMMENT '生成状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间'
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb3 COMMENT='系统_代码生成记录';
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COMMENT='系统_代码生成记录';
 
 --
 -- 转存表中的数据 `hg_sys_gen_codes`
@@ -1940,7 +1940,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_gen_curd_demo` (
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '修改时间',
   `deleted_at` datetime DEFAULT NULL COMMENT '删除时间'
-) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb3 COMMENT='系统_生成curd演示';
+) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb4 COMMENT='系统_生成curd演示';
 
 --
 -- 转存表中的数据 `hg_sys_gen_curd_demo`
@@ -1991,7 +1991,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_log` (
   `status` tinyint(1) NOT NULL DEFAULT '1' COMMENT '状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '修改时间'
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='系统_全局日志';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='系统_全局日志';
 
 -- --------------------------------------------------------
 
@@ -2011,7 +2011,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_login_log` (
   `status` tinyint(1) NOT NULL DEFAULT '1' COMMENT '状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '修改时间'
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='系统_登录日志';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='系统_登录日志';
 
 -- --------------------------------------------------------
 
@@ -2032,7 +2032,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_provinces` (
   `status` tinyint(1) NOT NULL DEFAULT '1' COMMENT '状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间'
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COMMENT='系统_省市区编码';
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COMMENT='系统_省市区编码';
 
 --
 -- 转存表中的数据 `hg_sys_provinces`
@@ -5737,7 +5737,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_serve_license` (
   `status` tinyint(1) DEFAULT '1' COMMENT '状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '修改时间'
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb3 COMMENT='系统_服务许可证';
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COMMENT='系统_服务许可证';
 
 --
 -- 转存表中的数据 `hg_sys_serve_license`
@@ -5764,7 +5764,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_serve_log` (
   `status` tinyint(1) NOT NULL DEFAULT '1' COMMENT '状态',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '修改时间'
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='系统_服务日志';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='系统_服务日志';
 
 -- --------------------------------------------------------
 
@@ -5782,7 +5782,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_sms_log` (
   `status` tinyint(1) DEFAULT '1' COMMENT '状态(1未验证,2已验证)',
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '更新时间'
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb3 COMMENT='系统_短信发送记录';
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COMMENT='系统_短信发送记录';
 
 --
 -- 转存表中的数据 `hg_sys_sms_log`
@@ -5807,7 +5807,7 @@ CREATE TABLE IF NOT EXISTS `hg_test_category` (
   `created_at` datetime DEFAULT NULL COMMENT '创建时间',
   `updated_at` datetime DEFAULT NULL COMMENT '修改时间',
   `deleted_at` datetime DEFAULT NULL COMMENT '删除时间'
-) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8mb3 COMMENT='测试分类';
+) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8mb4 COMMENT='测试分类';
 
 --
 -- 转存表中的数据 `hg_test_category`


### PR DESCRIPTION
## PR 缘由：

您好，我是上次 已经提过 PR https://github.com/bufanyun/hotgo/pull/80 的用户。
我的第一个基于 goframe 的项目已经顺利完结了，最近想做 goframe 相关的代码生成，今天有空想看看您的项目。
可能的话会考虑提 PR 对 sqlite 数据库的支持(我这边的项目都是优先考虑使用 sqlite 数据库)。

刚刚发现发布了新版 v2.13.1 ，但是发现 原先的 utf8md4 PR被覆盖了，原因是新版发布时数据库结构有调整。
没关系，我现在提交了基于 v2.13.1 的兼容数据库 sql 。

再次感谢您创建了如此优秀的项目。

## 解决了什么问题：

导入数据库(mariadb:11.2.2 + adminer:4.8.1)的过程中，发现了字符集的问题。

utf8mb4_0900_ai_ci 的字符集 是不存在的。

mariadb 是开源版本的 mysql。强烈建议使用 mariadb 作为默认数据库。
https://hub.docker.com/_/mariadb
一般来说都强烈建议数据库使用 utf8md4 的字符集。可以保证兼容世界上任何一种语言文字。
参考材料：

https://www.anbob.com/archives/6983.html
https://blog.csdn.net/BLWY_1124/article/details/126093478
我通过以下方式修改了server/storage/data/hotgo.sql文件。

```bash
cd hotgo/server/storage/data/
find . -name "*.sql" -type f -exec sed -i 's/utf8mb3/utf8mb4/g' {} +
find . -type f -name "*.sql" -exec sed -i 's/utf8mb4_0900_ai_ci/utf8mb4_general_ci/g' {} +
find . -type f -name "*.sql" -exec sed -i 's/utf8_general_ci/utf8mb4_general_ci/g' {} +
```
修改之后，我在以下环境下均测试通过(正确导入hotgo.sql数据，无错误无警告)：
```
mysql:8.0.28 + phpmyadmin:5.2.1
mariadb:11.2.2 + adminer:4.8.1
mysql:5.7.10 + phpmyadmin:5.2.1
```

## Tips:
本 fix 可以解决 https://github.com/bufanyun/hotgo/issues/79 的问题
