### PR TITLE
修复添加菜单填写了重定向，然后菜单类型为“菜单” 会执行重定向

### DIFF
--- a/web/src/router/generator-routers.ts
+++ b/web/src/router/generator-routers.ts
@@ -36,12 +36,16 @@ export const routerGenerator = (routerMap, parent?): any[] => {
 
     // 为了防止出现后端返回结果不规范，处理有可能出现拼接出两个 反斜杠
     currentRouter.path = currentRouter.path.replace('//', '/');
-    // 重定向
-    item.redirect && (currentRouter.redirect = item.redirect);
+    // 重定向 ,菜单类型为目录默认默认跳转
+    if(item.meta.type === 1){
+      item.redirect && (currentRouter.redirect = item.redirect);
+    }
     // 是否有子菜单，并递归处理
     if (item.children && item.children.length > 0) {
       //如果未定义 redirect 默认第一个子路由为 redirect
-      !item.redirect && (currentRouter.redirect = `${item.path}/${item.children[0].path}`);
+      if(item.meta.type === 1) {
+        !item.redirect && (currentRouter.redirect = `${item.path}/${item.children[0].path}`);
+      }
       // Recursion
       currentRouter.children = routerGenerator(item.children, currentRouter);
     }


### PR DESCRIPTION
流程：添加菜单，菜单类型"目录"填写了重定向地址，然后切换菜单类型为“菜单”保存
此时点击菜单会跳转到重定向地址，路由绑定的组件会无法访问