### PR TITLE
fix: #107

### DIFF
--- a/server/storage/data/hotgo.sql
+++ b/server/storage/data/hotgo.sql
@@ -1719,7 +1719,7 @@ CREATE TABLE IF NOT EXISTS `hg_sys_attachment` (
   `name` varchar(1000) DEFAULT NULL COMMENT '文件原始名',
   `kind` varchar(16) DEFAULT NULL COMMENT '上传类型',
   `mime_type` varchar(128) NOT NULL DEFAULT '' COMMENT '扩展类型',
-  `naive_type` varchar(32) NOT NULL COMMENT 'NaiveUI类型',
+  `naive_type` varchar(32) NOT NULL DEFAULT '' COMMENT 'NaiveUI类型',
   `path` varchar(1000) DEFAULT NULL COMMENT '本地路径',
   `file_url` varchar(1000) DEFAULT NULL COMMENT 'url',
   `size` bigint(20) DEFAULT '0' COMMENT '文件大小',


### PR DESCRIPTION
上传图片的时候，naive_type会被置空，导致保存失败。
https://github.com/hailaz/hotgo/blob/v2.0/server/internal/library/storager/upload.go#L200