### PR TITLE
fix(src/api/base/index.ts): 富文本无法上传图片

### DIFF
--- a/web/src/api/base/index.ts
+++ b/web/src/api/base/index.ts
@@ -16,6 +16,7 @@ export function UploadImage(params) {
   const headers = {
     Authorization: useUserStore.token,
     uploadType: 'default',
+    'Content-Type': 'multipart/form-data',
   };
   return http.request({
     url: '/upload/file',


### PR DESCRIPTION
富文本调用上传接口时，content-type 为 application/json导致无法上传图片，修改上传接口，指定 content-type 为 multipart/form-data解决问题

Closes #109