### PR TITLE
fix: 修复使用pnpm build打包报错

### DIFF
--- a/web/build/script/buildConf.ts
+++ b/web/build/script/buildConf.ts
@@ -10,7 +10,7 @@ import { getConfigFileName } from '../getConfigFileName';
 
 import pkg from '../../package.json';
 
-function createConfig(
+async function createConfig(
   {
     configName,
     config,
@@ -27,7 +27,7 @@ function createConfig(
         writable: false,
       });
     `.replace(/\s/g, '');
-    fs.mkdirp(getRootPath(OUTPUT_DIR));
+    await fs.mkdirp(getRootPath(OUTPUT_DIR));
     fs.writeFileSync(getRootPath(`${OUTPUT_DIR}/${configFileName}`), configStr);
 
     console.log(chalk.cyan(`✨ [${pkg.name}]`) + ` - configuration file is build successfully:`);
@@ -37,8 +37,8 @@ function createConfig(
   }
 }
 
-export function runBuildConfig() {
+export async function runBuildConfig() {
   const config = getEnvConfig();
   const configFileName = getConfigFileName(config);
-  createConfig({ config, configName: configFileName });
+  await createConfig({ config, configName: configFileName });
 }

--- a/web/build/script/postBuild.ts
+++ b/web/build/script/postBuild.ts
@@ -2,7 +2,7 @@
 
 import { runBuildConfig } from './buildConf';
 import chalk from 'chalk';
-
+import process from 'node:process'
 import pkg from '../../package.json';
 
 export const runBuild = async () => {
@@ -20,4 +20,4 @@ export const runBuild = async () => {
     process.exit(1);
   }
 };
-runBuild();
+runBuild().then();

--- a/web/package.json
+++ b/web/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.4.1",
     "@commitlint/config-conventional": "^19.4.1",
+    "@types/fs-extra": "^11.0.4",
     "@types/lodash": "^4.17.7",
     "@types/node": "^22.5.2",
     "@typescript-eslint/eslint-plugin": "^8.4.0",
@@ -75,6 +76,7 @@
     "@vue/compiler-sfc": "^3.4.38",
     "@vue/eslint-config-typescript": "^13.0.0",
     "autoprefixer": "^10.4.20",
+    "chalk": "^5.3.0",
     "commitizen": "^4.3.0",
     "core-js": "^3.38.1",
     "cross-env": "^7.0.3",
@@ -87,6 +89,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-vue": "^9.28.0",
     "esno": "^4.7.0",
+    "fs-extra": "^11.2.0",
     "gh-pages": "^6.1.1",
     "husky": "^9.1.5",
     "jest": "^29.7.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^19.4.1
         version: 19.4.1
+      '@types/fs-extra':
+        specifier: ^11.0.4
+        version: 11.0.4
       '@types/lodash':
         specifier: ^4.17.7
         version: 4.17.7
@@ -141,6 +144,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.44)
+      chalk:
+        specifier: ^5.3.0
+        version: 5.3.0
       commitizen:
         specifier: ^4.3.0
         version: 4.3.0(@types/node@22.5.2)(typescript@5.5.4)
@@ -177,6 +183,9 @@ importers:
       esno:
         specifier: ^4.7.0
         version: 4.7.0
+      fs-extra:
+        specifier: ^11.2.0
+        version: 11.2.0
       gh-pages:
         specifier: ^6.1.1
         version: 6.1.1
@@ -1264,6 +1273,9 @@ packages:
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
+  '@types/fs-extra@11.0.4':
+    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
+
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
@@ -1278,6 +1290,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/jsonfile@6.1.4':
+    resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
   '@types/katex@0.16.7':
     resolution: {integrity: sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==}
@@ -5643,6 +5658,11 @@ snapshots:
 
   '@types/estree@1.0.5': {}
 
+  '@types/fs-extra@11.0.4':
+    dependencies:
+      '@types/jsonfile': 6.1.4
+      '@types/node': 22.5.2
+
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 22.5.2
@@ -5659,6 +5679,10 @@ snapshots:
 
   '@types/json-schema@7.0.15':
     optional: true
+
+  '@types/jsonfile@6.1.4':
+    dependencies:
+      '@types/node': 22.5.2
 
   '@types/katex@0.16.7': {}
 


### PR DESCRIPTION
使用pnpm 会缺少 fs-extra和chalk依赖,导致打包时报错
![609a6bb08b9a177d19812a7f13bed389](https://github.com/user-attachments/assets/b1fc06a4-a484-43a9-9eae-428dc6c73124)
