### PR TITLE
fix: 修复lodash-es类型错误

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -68,7 +68,7 @@
     "@commitlint/config-conventional": "^19.4.1",
     "@eslint/eslintrc": "^3.1.0",
     "@types/fs-extra": "^11.0.4",
-    "@types/lodash": "^4.17.7",
+    "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.5.2",
     "@typescript-eslint/eslint-plugin": "^8.4.0",
     "@typescript-eslint/parser": "^8.4.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -120,9 +120,9 @@ importers:
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
-      '@types/lodash':
-        specifier: ^4.17.7
-        version: 4.17.7
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       '@types/node':
         specifier: ^22.5.2
         version: 22.5.2

--- a/web/src/hooks/useDomWidth.ts
+++ b/web/src/hooks/useDomWidth.ts
@@ -1,5 +1,5 @@
 import { ref, onMounted, onUnmounted } from 'vue';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 
 /**
  * description: 获取页面宽度


### PR DESCRIPTION
项目里使用的是lodash-es,开发类型安装的为@types/lodash
![image](https://github.com/user-attachments/assets/9767b101-ec4f-439b-81d9-07ed63712e51)
