### PR TITLE
fix:处理分页结构体PerPage的json别名pageSize 无法被验证导致 pageSize传0也能正常访问而导致数据库无分页拉爆…

### DIFF
--- a/server/internal/model/input/form/page.go
+++ b/server/internal/model/input/form/page.go
@@ -17,7 +17,7 @@ type ReqPageFunc interface {
 // PageReq 分页请求
 type PageReq struct {
 	Page       int  `json:"page" example:"10" d:"1" v:"page@min:1#页码最小值不能低于1"  dc:"当前页码"`
-	PerPage    int  `json:"pageSize" example:"1" d:"10" v:"pageSize@min:1|max:200#每页数量最小值不能低于1|最大值不能大于200" dc:"每页数量"`
+	PerPage    int  `json:"pageSize" example:"1" d:"10" v:"pageSize@min:1|max:200#每页数量最小值不能低于1|每页数量最大值不能大于200" dc:"每页数量"`
 	Pagination bool `json:"pagination" d:"true" dc:"是否需要进行分页"`
 }
 

--- a/server/internal/model/input/form/page.go
+++ b/server/internal/model/input/form/page.go
@@ -16,8 +16,8 @@ type ReqPageFunc interface {
 
 // PageReq 分页请求
 type PageReq struct {
-	Page       int  `json:"page" example:"10" d:"1" v:"min:1#页码最小值不能低于1"  dc:"当前页码"`
-	PerPage    int  `json:"pageSize" example:"1" d:"10" v:"min:1|max:200#每页数量最小值不能低于1|最大值不能大于200" dc:"每页数量"`
+	Page       int  `json:"page" example:"10" d:"1" v:"page@min:1#页码最小值不能低于1"  dc:"当前页码"`
+	PerPage    int  `json:"pageSize" example:"1" d:"10" v:"pageSize@min:1|max:200#每页数量最小值不能低于1|最大值不能大于200" dc:"每页数量"`
 	Pagination bool `json:"pagination" d:"true" dc:"是否需要进行分页"`
 }
 


### PR DESCRIPTION
fix:处理分页结构体PerPage的json别名pageSize 无法被验证导致 pageSize传0也能正常访问而导致数据库无分页拉爆数据库的问题

文档:https://goframe.org/docs/core/gvalid-parameter-type-struct-example