### PR TITLE
修复模版生成model.ts表字段如果有默认值不带引号的问题

### DIFF
--- a/server/internal/library/hggen/views/curd_generate_web_model.go
+++ b/server/internal/library/hggen/views/curd_generate_web_model.go
@@ -14,6 +14,7 @@ import (
 	"hotgo/internal/library/dict"
 	"hotgo/internal/model/input/sysin"
 	"hotgo/utility/convert"
+	"strings"
 
 	"github.com/gogf/gf/v2/errors/gerror"
 	"github.com/gogf/gf/v2/frame/g"
@@ -24,6 +25,7 @@ type StateItem struct {
 	Name         string
 	DefaultValue interface{}
 	Dc           string
+	DataType     string // 新增字段：存储字段类型信息
 }
 
 func (l *gCurd) webModelTplData(ctx context.Context, in *CurdPreviewInput) (data g.Map, err error) {
@@ -112,13 +114,20 @@ func (l *gCurd) generateWebModelImport(ctx context.Context, in *CurdPreviewInput
 
 func (l *gCurd) generateWebModelStateItems(ctx context.Context, in *CurdPreviewInput) (items []*StateItem) {
 	for _, field := range in.masterFields {
+		dataType := field.DataType
+		if dataType == "" && field.SqlType != "" {
+			if parts := strings.SplitN(field.SqlType, "(", 2); len(parts) > 0 {
+				dataType = parts[0]
+			}
+		}
 		var value = field.DefaultValue
 		if value == nil {
 			value = "null"
 		}
-		if value == "" {
-			value = `''`
-		}
+		//注释为空判断 避免模版生成的model.ts重复加引号
+		//if value == "" {
+		//	value = `''`
+		//}
 
 		// 选项组件默认值调整
 		if gconv.Int(value) == 0 && IsSelectFormMode(field.FormMode) {
@@ -145,6 +154,7 @@ func (l *gCurd) generateWebModelStateItems(ctx context.Context, in *CurdPreviewI
 			items = append(items, &StateItem{
 				Name:         field.TsName + "Summa?: null | MemberSumma",
 				DefaultValue: "null",
+				DataType:     dataType,
 				Dc:           field.Dc + "摘要信息",
 			})
 		}

--- a/server/resource/generate/default/curd/web.model.ts.template
+++ b/server/resource/generate/default/curd/web.model.ts.template
@@ -2,9 +2,16 @@
 
 @{.const}
 
-export class State {@{range .stateItems}
-  public @{.Name} = @{.DefaultValue}; // @{.Dc}@{end}
-
+export class State {
+@{range .stateItems}
+  public @{.Name} = @{if and .DataType (or
+      (eq .DataType "varchar")
+      (eq .DataType "char")
+      (eq .DataType "text")
+      (eq .DataType "json")
+      (eq .DataType "date")
+      (eq .DataType "datetime")
+    )}'@{.DefaultValue}'@{else}@{.DefaultValue}@{end};//@{.Dc}@{end}
   constructor(state?: Partial<State>) {
     if (state) {
       Object.assign(this, state);


### PR DESCRIPTION

<img width="1053" height="700" alt="bug1" src="https://github.com/user-attachments/assets/3c7be9df-e77b-4778-ae45-d4b71e58483a" />

<img width="342" height="288" alt="bug2" src="https://github.com/user-attachments/assets/b5533acf-5161-4b56-94f9-ce52e80f26fc" />
生成代码遇到数据库表字段有默认值属性的生成的前端model.ts默认值没有带引号