### PR TITLE
修复新增按钮类型的菜单到hg_admin_menu时，component空串被清空导致新增失败

### DIFF
--- a/server/internal/logic/admin/menu.go
+++ b/server/internal/logic/admin/menu.go
@@ -111,7 +111,7 @@ func (s *sAdminMenu) Edit(ctx context.Context, in *adminin.MenuEditInp) (err err
 				return err
 			}
 		} else {
-			if _, err = dao.AdminMenu.Ctx(ctx).Data(in).OmitEmptyData().Insert(); err != nil {
+			if _, err = dao.AdminMenu.Ctx(ctx).Data(in).OmitNilData().Insert(); err != nil {
 				err = gerror.Wrap(err, "新增菜单失败！")
 				return err
 			}


### PR DESCRIPTION
修复新增按钮类型的菜单到hg_admin_menu时，component空串被清空导致新增失败